### PR TITLE
feat: allow metadata to be set on catastrophes

### DIFF
--- a/lib/src/cards/catastrophe.ts
+++ b/lib/src/cards/catastrophe.ts
@@ -189,29 +189,30 @@ const deusExMachina: CatastopheCard = {
   pack: 'Classic',
   calcC: (inst: CardInstance, allPlayerCards: Array<Array<CardInstance>>) => {
     allPlayerCards.forEach((playerCards, position) => {
-      if (!(inst.metadata.drawn_face_values instanceof Array)) {
-        throw new Error('invalid data for metadata field drawn_face_values');
-      }
-      const faceValue = inst.metadata.drawn_face_values![position];
-      if (typeof faceValue !== 'number') {
-        throw new Error(
-          `no drawn face value specified for Player ${position + 1}`
-        );
-      }
       const active = activeCards(playerCards);
-      if (active.length > 0) {
-        active[0].applyPoints(
-          'C',
-          faceValue as number,
-          inst,
-          'for drawing a trait with face value of ' + faceValue
-        );
+      if ((inst.metadata.drawn_face_values instanceof Array)) {
+        const faceValue = inst.metadata.drawn_face_values![position];
+        // TODO: add number[] as a valid type - we currently only support number or string[]
+        const parsedValue = parseInt(faceValue);
+        if (typeof parsedValue !== 'number') {
+          throw new Error(
+            `no drawn face value specified for Player ${position + 1}`
+          );
+        }
+        if (active.length > 0) {
+          active[0].applyPoints(
+            'C',
+            parsedValue as number,
+            inst,
+            'for drawing a trait with face value of ' + faceValue
+          );
+        }
       }
     });
 
     // TODO: would be nice if this allow selection by card name
   },
-  metadataRequired: [['drawn_face_values', 'card_per_person', 'global']]
+  metadataRequired: [['drawn_face_values', 'card_per_person', 'card']]
 };
 addCard(deusExMachina);
 

--- a/lib/src/cards/index.ts
+++ b/lib/src/cards/index.ts
@@ -3,7 +3,7 @@ import './ages';
 import './b-cards';
 import './c-cards';
 import './d-cards';
-import './catastophe';
+import './catastrophe';
 import './e-cards';
 import './f-cards';
 import './g-cards';

--- a/web/src/App.css
+++ b/web/src/App.css
@@ -2,8 +2,16 @@
 body {
   background: #f5f3f0;
   background-image:
-    radial-gradient(ellipse at 20% 50%, rgba(102, 126, 234, 0.06) 0%, transparent 60%),
-    radial-gradient(ellipse at 80% 20%, rgba(118, 75, 162, 0.05) 0%, transparent 50%);
+    radial-gradient(
+      ellipse at 20% 50%,
+      rgba(102, 126, 234, 0.06) 0%,
+      transparent 60%
+    ),
+    radial-gradient(
+      ellipse at 80% 20%,
+      rgba(118, 75, 162, 0.05) 0%,
+      transparent 50%
+    );
   min-height: 100vh;
 }
 
@@ -13,7 +21,12 @@ body {
   margin: 0 auto;
   padding: 20px;
   font-family:
-    'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+    'Inter',
+    -apple-system,
+    BlinkMacSystemFont,
+    'Segoe UI',
+    Roboto,
+    sans-serif;
   padding-top: 200px;
 }
 
@@ -39,8 +52,13 @@ body {
 }
 
 @keyframes headerGradient {
-  0%, 100% { background-position: 0% 50%; }
-  50% { background-position: 100% 50%; }
+  0%,
+  100% {
+    background-position: 0% 50%;
+  }
+  50% {
+    background-position: 100% 50%;
+  }
 }
 
 .header-top {
@@ -311,18 +329,15 @@ body {
   width: 100%;
   height: auto;
   display: block;
-  background: linear-gradient(
-    110deg,
-    #e8e8e8 8%,
-    #f5f5f5 18%,
-    #e8e8e8 33%
-  );
+  background: linear-gradient(110deg, #e8e8e8 8%, #f5f5f5 18%, #e8e8e8 33%);
   background-size: 200% 100%;
   animation: shimmer 1.5s linear infinite;
 }
 
 @keyframes shimmer {
-  to { background-position: -200% 0; }
+  to {
+    background-position: -200% 0;
+  }
 }
 
 .pack-card {
@@ -362,7 +377,9 @@ body {
   flex-shrink: 0;
   cursor: pointer;
   overflow: visible;
-  transition: transform 0.25s cubic-bezier(0.4, 0, 0.2, 1), box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1);
+  transition:
+    transform 0.25s cubic-bezier(0.4, 0, 0.2, 1),
+    box-shadow 0.25s cubic-bezier(0.4, 0, 0.2, 1);
 }
 
 .player-card:hover {
@@ -392,7 +409,11 @@ body {
   bottom: 2px;
   left: 10%;
   right: 10%;
-  background: linear-gradient(135deg, rgba(22, 163, 74, 0.95), rgba(21, 128, 61, 0.95));
+  background: linear-gradient(
+    135deg,
+    rgba(22, 163, 74, 0.95),
+    rgba(21, 128, 61, 0.95)
+  );
   color: white;
   padding: 2px 4px;
   border-radius: 4px;
@@ -440,6 +461,7 @@ body {
 /* Metadata missing indicator */
 .metadata-missing {
   box-shadow: 0 0 0 3px rgba(220, 53, 69, 0.8);
+  background-color: rgba(220, 53, 69, 0.8);
   animation: pulse-red 2s ease-in-out infinite;
 }
 
@@ -447,9 +469,11 @@ body {
   0%,
   100% {
     box-shadow: 0 0 0 3px rgba(220, 53, 69, 0.8);
+    background-color: rgba(220, 53, 69, 0.8);
   }
   50% {
     box-shadow: 0 0 0 5px rgba(220, 53, 69, 0.4);
+    background-color: rgba(220, 53, 69, 0.4);
   }
 }
 
@@ -470,8 +494,12 @@ body {
 }
 
 @keyframes fadeIn {
-  from { opacity: 0; }
-  to { opacity: 1; }
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
 }
 
 .modal-content {
@@ -530,6 +558,7 @@ body {
   color: #495057;
   margin-bottom: 6px;
   font-size: 14px;
+  white-space: nowrap;
 }
 
 .field-scope {
@@ -1391,4 +1420,3 @@ button:active {
     transition-duration: 0.01ms !important;
   }
 }
-

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,11 +2,12 @@ import { useReducer, useEffect, useState, useCallback, useRef } from 'react';
 import { allCards } from '@scorer/cardContainer';
 import { PACK_TYPES } from '@scorer/types';
 import '@scorer/cards';
-import type { Card, ModalState } from './types';
-import type { PlayerState, PlayerCardEntry } from './types';
+import type { Card, CatastropheModalState, ModalState } from './types';
+import type { PlayerState, CardEntry } from './types';
 import { useScorer } from './hooks/useScorer';
 import {
   getCardMetadataFields,
+  getCatastropheMetadataFields,
   getEditableMetadataFields,
   getInternalMetadataFields
 } from './utils/cardMetadata';
@@ -23,13 +24,14 @@ interface AppState {
   selectedPlayerId: number | null;
   selectedPacks: string[];
   playerCount: number;
-  selectedCatastrophes: string[];
+  selectedCatastrophes: CardEntry[];
   catastropheMetadata: Record<
     string,
     Record<string, string | number | string[]>
   >;
   hoveredCard: string | null;
   modal: ModalState | null;
+  catastropheModal: CatastropheModalState | null;
   mobileAddingForPlayer: number | null;
 }
 
@@ -47,14 +49,20 @@ type Action =
       cardIndex: number;
       cardName: string;
     }
+  | { type: 'OPEN_CATASTROPHE_MODAL'; cardName: string }
   | { type: 'CLOSE_MODAL' }
   | {
       type: 'UPDATE_CARD_METADATA';
       playerId: number;
       cardIndex: number;
       cardName: string;
-      values: Record<string, string | number>;
+      values: Record<string, string | number | string[]>;
       scope: string;
+    }
+  | {
+      type: 'UPDATE_CATASTROPHE_CARD_METADATA';
+      cardName: string;
+      values: Record<string, string | number | string[]>;
     }
   | {
       type: 'UPDATE_CATASTROPHE_METADATA';
@@ -80,7 +88,7 @@ function applyMetadataByScope(
   playerId: number,
   cardIndex: number,
   cardName: string,
-  values: Record<string, string | number>,
+  values: Record<string, string | number | string[]>,
   scope: string
 ): PlayerState[] {
   return players.map((p) => {
@@ -139,7 +147,7 @@ function reducer(state: AppState, action: Action): AppState {
     case 'ADD_CARD': {
       const fields = getCardMetadataFields(action.cardName);
       const editableFields = fields.filter((f) => f.scope !== 'internal');
-      const entry: PlayerCardEntry = { name: action.cardName };
+      const entry: CardEntry = { name: action.cardName };
 
       // For player/global scoped metadata, copy values from existing cards
       if (editableFields.length > 0) {
@@ -195,17 +203,20 @@ function reducer(state: AppState, action: Action): AppState {
     case 'SET_PACKS':
       return { ...state, selectedPacks: action.packs };
     case 'TOGGLE_CATASTROPHE': {
-      const has = state.selectedCatastrophes.includes(action.cardName);
+      const has = state.selectedCatastrophes.find(
+        (c) => c.name === action.cardName
+      );
       const newCatastrophes = has
-        ? state.selectedCatastrophes.filter((n) => n !== action.cardName)
-        : [...state.selectedCatastrophes, action.cardName];
+        ? state.selectedCatastrophes.filter((n) => n.name !== action.cardName)
+        : [...state.selectedCatastrophes, { name: action.cardName }];
       // Clean up metadata for removed catastrophes
       const newCatMeta = { ...state.catastropheMetadata };
+      let currentState = { ...state };
       if (has) {
         delete newCatMeta[action.cardName];
       }
       return {
-        ...state,
+        ...currentState,
         selectedCatastrophes: newCatastrophes,
         catastropheMetadata: newCatMeta
       };
@@ -221,9 +232,16 @@ function reducer(state: AppState, action: Action): AppState {
           cardName: action.cardName
         }
       };
+    case 'OPEN_CATASTROPHE_MODAL':
+      return {
+        ...state,
+        catastropheModal: {
+          cardName: action.cardName
+        }
+      };
     case 'CLOSE_MODAL':
-      return { ...state, modal: null };
-    case 'UPDATE_CARD_METADATA':
+      return { ...state, modal: null, catastropheModal: null };
+    case 'UPDATE_CARD_METADATA': {
       return {
         ...state,
         players: applyMetadataByScope(
@@ -236,6 +254,27 @@ function reducer(state: AppState, action: Action): AppState {
         ),
         modal: null
       };
+    }
+    case 'UPDATE_CATASTROPHE_CARD_METADATA': {
+      // catastrophe card
+      const selectedCatastrophes = state.selectedCatastrophes.map(
+        (selectedCatastrophe) => {
+          if (selectedCatastrophe.name === action.cardName) {
+            return {
+              ...selectedCatastrophe,
+              ...action.values
+            };
+          }
+          return selectedCatastrophe;
+        }
+      );
+
+      return {
+        ...state,
+        selectedCatastrophes,
+        catastropheModal: null
+      };
+    }
     case 'UPDATE_CATASTROPHE_METADATA':
       return {
         ...state,
@@ -299,6 +338,7 @@ const initialState: AppState = {
   selectedCatastrophes: [],
   catastropheMetadata: {},
   hoveredCard: null,
+  catastropheModal: null,
   modal: null,
   mobileAddingForPlayer: null
 };
@@ -341,7 +381,6 @@ export default function App() {
 
   // Merge catastrophe generated metadata back into state
   const prevCatMetaRef = useRef<string>('');
-  const prevPlayerGemMetaRef = useRef<string>('');
   useEffect(() => {
     if (!gameScore) return;
     const catGenMeta = gameScore.getCatastropheGeneratedMetadata();
@@ -351,9 +390,9 @@ export default function App() {
         string,
         Record<string, string | number | string[]>
       > = {};
-      state.selectedCatastrophes.forEach((name, i) => {
+      state.selectedCatastrophes.forEach((catastrophe, i) => {
         if (catGenMeta[i] && Object.keys(catGenMeta[i]).length > 0) {
-          newMeta[name] = catGenMeta[i];
+          newMeta[catastrophe.name] = catGenMeta[i];
         }
       });
 
@@ -483,13 +522,19 @@ export default function App() {
     dispatch({ type: 'SET_HOVERED', cardName });
   }, []);
 
-  const handleToggleCatastrophe = useCallback((cardName: string) => {
-    dispatch({ type: 'TOGGLE_CATASTROPHE', cardName });
-  }, []);
+  const handleClickCatastrophe = useCallback(
+    (cardName: string) => {
+      if (!state.selectedCatastrophes.find((c) => c.name === cardName)) {
+        dispatch({ type: 'TOGGLE_CATASTROPHE', cardName });
+      }
+      dispatch({ type: 'OPEN_CATASTROPHE_MODAL', cardName: cardName });
+    },
+    [state.selectedCatastrophes, state.catastropheMetadata]
+  );
 
   const handleDeselectCatastrophe = useCallback(
     (cardName: string) => {
-      if (state.selectedCatastrophes.includes(cardName)) {
+      if (state.selectedCatastrophes.find((c) => c.name === cardName)) {
         dispatch({ type: 'TOGGLE_CATASTROPHE', cardName });
       }
     },
@@ -507,6 +552,18 @@ export default function App() {
     ? state.players.find((p) => p.id === state.modal!.playerId)?.cards[
         state.modal.cardIndex
       ]
+    : null;
+
+  // Modal data - separate editable fields from internal
+  const catName = state.catastropheModal?.cardName;
+  const catModalEditableFields = state.catastropheModal
+    ? getEditableMetadataFields(catName!)
+    : [];
+  const catModalInternalFields = state.catastropheModal
+    ? getCatastropheMetadataFields(state.catastropheMetadata[catName!])
+    : [];
+  const catModalCard = state.catastropheModal
+    ? state.selectedCatastrophes.find((c) => c.name === catName)
     : null;
 
   // Build internal values from generated metadata in game score
@@ -527,6 +584,26 @@ export default function App() {
     }
   }
 
+  // Build internal values from generated metadata in game score
+  const catModalInternalValues: Record<string, string | number | string[]> = {};
+  if (
+    state.catastropheModal &&
+    gameScore &&
+    catModalInternalFields.length > 0
+  ) {
+    try {
+      const catIndex = state.selectedCatastrophes.findIndex(
+        (c) => c.name === state.catastropheModal!.cardName
+      );
+      const metadata = gameScore.getCatastropheGeneratedMetadata()[catIndex];
+      if (metadata) {
+        Object.assign(catModalInternalValues, metadata);
+      }
+    } catch {
+      // Catastrophe may not have generated metadata
+    }
+  }
+
   // Determine the dominant scope for save propagation (only from editable fields)
   const modalScope =
     modalEditableFields.length > 0
@@ -537,10 +614,14 @@ export default function App() {
           : 'card'
       : 'card';
 
+  const catModalScope = 'card';
+
   // Show modal if there are any fields (editable or internal)
   const hasAnyModalFields =
     modalEditableFields.length > 0 || modalInternalFields.length > 0;
 
+  const hasAnyCatModalFields =
+    catModalEditableFields.length > 0 || catModalInternalFields.length > 0;
   let playerCardNames: string[] = [];
   if (state.selectedPlayerId !== null) {
     const player = state.players.find((p) => p.id === state.selectedPlayerId);
@@ -586,7 +667,7 @@ export default function App() {
         onClickCard={handleClickCard}
         onHover={handleHover}
         selectedCatastrophes={state.selectedCatastrophes}
-        onToggleCatastrophe={handleToggleCatastrophe}
+        onClickCatastrophe={handleClickCatastrophe}
         onDeselectCatastrophe={handleDeselectCatastrophe}
       />
 
@@ -594,6 +675,7 @@ export default function App() {
         <MetadataModal
           cardName={state.modal.cardName}
           playerCardNames={playerCardNames}
+          playerCount={state.playerCount}
           selectedCatastrophes={state.selectedCatastrophes}
           fields={modalEditableFields}
           internalFields={modalInternalFields}
@@ -607,6 +689,27 @@ export default function App() {
               cardName: state.modal!.cardName,
               values,
               scope: modalScope
+            })
+          }
+          onClose={() => dispatch({ type: 'CLOSE_MODAL' })}
+        />
+      )}
+
+      {state.catastropheModal && catModalCard && hasAnyCatModalFields && (
+        <MetadataModal
+          cardName={state.catastropheModal.cardName}
+          playerCardNames={[]}
+          playerCount={state.playerCount}
+          selectedCatastrophes={[]}
+          fields={catModalEditableFields}
+          internalFields={catModalInternalFields}
+          internalValues={catModalInternalValues}
+          currentValues={catModalCard}
+          onSave={(values) =>
+            dispatch({
+              type: 'UPDATE_CATASTROPHE_CARD_METADATA',
+              cardName: state.catastropheModal!.cardName,
+              values
             })
           }
           onClose={() => dispatch({ type: 'CLOSE_MODAL' })}

--- a/web/src/components/MetadataModal.tsx
+++ b/web/src/components/MetadataModal.tsx
@@ -1,17 +1,18 @@
 import { useState, useEffect } from 'react';
-import { TRAIT_CARD_TYPES } from '@scorer/types';
+import { Card, TRAIT_CARD_TYPES } from '@scorer/types';
 import type { MetadataField } from '../utils/cardMetadata';
-import type { PlayerCardEntry } from '../types';
+import type { CardEntry } from '../types';
 
 interface MetadataModalProps {
   cardName: string;
-  selectedCatastrophes: string[];
+  selectedCatastrophes: CardEntry[];
   playerCardNames: string[];
+  playerCount: number;
   fields: MetadataField[];
   internalFields: MetadataField[];
   internalValues: Record<string, string | number | string[]>;
-  currentValues: PlayerCardEntry;
-  onSave: (values: Record<string, string | number>) => void;
+  currentValues: CardEntry;
+  onSave: (values: Record<string, string | number | string[]>) => void;
   onClose: () => void;
 }
 
@@ -36,6 +37,7 @@ export default function MetadataModal({
   cardName,
   selectedCatastrophes,
   playerCardNames,
+  playerCount,
   fields,
   internalFields,
   internalValues,
@@ -44,25 +46,50 @@ export default function MetadataModal({
   onClose
 }: MetadataModalProps) {
   const [values, setValues] = useState<Record<string, string | number>>({});
+  const [arrayValues, setArrayValues] = useState<Record<string, string[]>>({});
+
   const hasEditableFields = fields.length > 0;
 
   useEffect(() => {
     const initial: Record<string, string | number> = {};
+    const initialArray: Record<string, string[]> = {};
     fields.forEach((f) => {
-      const existing = currentValues[f.key];
-      if (existing !== undefined && existing !== '') {
-        initial[f.key] = existing as string | number;
+      if (f.type === 'card_per_person') {
+        const existing = currentValues[f.key];
+        if (existing !== undefined && existing !== '') {
+          initialArray[f.key] = existing as string[];
+        } else {
+          initialArray[f.key] = Array.from(
+            { length: playerCount },
+            (_, pos) => pos
+          ).map(() => '');
+        }
+      } else {
+        const existing = currentValues[f.key];
+        if (existing !== undefined && existing !== '') {
+          initial[f.key] = existing as string | number;
+        }
       }
     });
     setValues(initial);
+    setArrayValues(initialArray);
   }, [fields, currentValues]);
 
   const allValid = fields.every((f) => {
     const val = values[f.key];
-    if (val === undefined || val === '') return false;
-    if (f.type === 'number' || f.type === 'catastrophe')
-      return typeof val === 'number' || !isNaN(Number(val));
-    return true;
+    if (val) {
+      if (val === '') return false;
+      if (f.type === 'number' || f.type === 'catastrophe')
+        return typeof val === 'number' || !isNaN(Number(val));
+      return true;
+    }
+    const arrayVal = arrayValues[f.key];
+    if (arrayVal) {
+      if (arrayVal.length === 0) return false;
+      if (arrayVal.some((v) => v === '')) return false;
+      return true;
+    }
+    return false;
   });
 
   function handleSubmit(e: React.FormEvent) {
@@ -72,10 +99,16 @@ export default function MetadataModal({
       return;
     }
     if (!allValid) return;
-    const coerced: Record<string, string | number> = {};
+    const coerced: Record<string, string | number | string[]> = {};
     fields.forEach((f) => {
       const val = values[f.key];
-      coerced[f.key] = f.type === 'number' ? Number(val) : val;
+      if (val) {
+        coerced[f.key] = f.type === 'number' ? Number(val) : val;
+      }
+      const arrayVal = arrayValues[f.key];
+      if (arrayVal) {
+        coerced[f.key] = arrayVal;
+      }
     });
     onSave(coerced);
   }
@@ -114,8 +147,9 @@ export default function MetadataModal({
                     <option key={`catastrophe-${position}`} value={position}>
                       {/* populate the catastrophe name here from the index if it
                       has been selected */}
-                      {selectedCatastrophes[position] ||
-                        `Catastrophe ${position + 1}`}
+                      {selectedCatastrophes[position]
+                        ? selectedCatastrophes[position].name
+                        : `Catastrophe ${position + 1}`}
                     </option>
                   ))}
                 </select>
@@ -166,6 +200,32 @@ export default function MetadataModal({
                   ))}
                 </select>
               )}
+              {field.type === 'card_per_person' &&
+                Array.from({ length: playerCount }, (_, pos) => pos).map(
+                  (pos) => {
+                    if (!arrayValues[field.key]) arrayValues[field.key] = [];
+                    return (
+                      <label>
+                        Player {pos + 1}:
+                        <input
+                          id={`meta-${field.key}-${pos}`}
+                          type="number"
+                          value={arrayValues[field.key][pos] ?? ''}
+                          onChange={(e) =>
+                            setArrayValues((v) => {
+                              const newValues = [...v[field.key]];
+                              newValues[pos] = e.target.value;
+                              return {
+                                ...v,
+                                [field.key]: newValues
+                              };
+                            })
+                          }
+                        />
+                      </label>
+                    );
+                  }
+                )}
             </div>
           ))}
 

--- a/web/src/components/PackDisplay.tsx
+++ b/web/src/components/PackDisplay.tsx
@@ -1,5 +1,5 @@
 import { useState, useMemo, useCallback } from 'react';
-import type { Card, CardType } from '../types';
+import type { Card, CardEntry, CardType } from '../types';
 import { TRAIT_CARD_TYPES } from '@scorer/types';
 import { useMediaQuery } from '../hooks/useMediaQuery';
 import { useHeaderBottom } from '../hooks/useHeaderBottom';
@@ -7,6 +7,7 @@ import ColorTabs, { type TabId } from './ColorTabs';
 import SearchBar from './SearchBar';
 import CardGrid from './CardGrid';
 import BottomDrawer from './BottomDrawer';
+import { getCatastropheMetadataFields } from 'src/utils/cardMetadata';
 
 interface PackDisplayProps {
   cards: Map<string, Card>;
@@ -15,8 +16,8 @@ interface PackDisplayProps {
   mobileAddingForPlayer: number | null;
   onClickCard: (cardName: string) => void;
   onHover: (cardName: string | null) => void;
-  selectedCatastrophes: string[];
-  onToggleCatastrophe: (cardName: string) => void;
+  selectedCatastrophes: CardEntry[];
+  onClickCatastrophe: (cardName: string) => void;
   onDeselectCatastrophe: (cardName: string) => void;
 }
 
@@ -28,7 +29,7 @@ export default function PackDisplay({
   onClickCard,
   onHover,
   selectedCatastrophes,
-  onToggleCatastrophe,
+  onClickCatastrophe,
   onDeselectCatastrophe
 }: PackDisplayProps) {
   const isDesktop = useMediaQuery('(min-width: 768px)');
@@ -105,7 +106,9 @@ export default function PackDisplay({
     if (activeTab !== 'catastrophe') return [];
     return [...catastropheCards]
       .filter(
-        (card) => selectedCatastrophes.includes(card.name) || isVisible(card)
+        (card) =>
+          selectedCatastrophes.find((c) => c.name === card.name) ||
+          isVisible(card)
       )
       .sort((a, b) => a.name.localeCompare(b.name));
   }, [activeTab, catastropheCards, selectedPacks, searchQuery, isSearching]);
@@ -143,7 +146,7 @@ export default function PackDisplay({
             <CatastropheInline
               catastropheCards={filteredCatastrophes}
               selectedCatastrophes={selectedCatastrophes}
-              onToggle={onToggleCatastrophe}
+              clickCard={onClickCatastrophe}
               onDeselect={onDeselectCatastrophe}
               onHover={onHover}
             />
@@ -153,7 +156,7 @@ export default function PackDisplay({
         <CatastropheInline
           catastropheCards={filteredCatastrophes}
           selectedCatastrophes={selectedCatastrophes}
-          onToggle={onToggleCatastrophe}
+          clickCard={onClickCatastrophe}
           onDeselect={onDeselectCatastrophe}
           onHover={onHover}
         />
@@ -199,13 +202,15 @@ export default function PackDisplay({
 function CatastropheInline({
   catastropheCards,
   selectedCatastrophes,
-  onToggle,
+  playerCount,
+  clickCard,
   onDeselect,
   onHover
 }: {
   catastropheCards: Card[];
-  selectedCatastrophes: string[];
-  onToggle: (name: string) => void;
+  selectedCatastrophes: CardEntry[];
+  playerCount: number;
+  clickCard: (name: string) => void;
   onDeselect: (name: string) => void;
   onHover: (name: string | null) => void;
 }) {
@@ -213,12 +218,42 @@ function CatastropheInline({
     <div className="catastrophe-tab-content">
       <div className="catastrophe-cards">
         {catastropheCards.map((card) => {
-          const isSelected = selectedCatastrophes.includes(card.name);
+          const isSelected = selectedCatastrophes.find(
+            (c) => c.name === card.name
+          );
+          const requiredMetadata =
+            isSelected &&
+            card.metadataRequired &&
+            card.metadataRequired.filter(
+              ([_, __, scope]) => scope !== 'internal'
+            );
+
+          const missingMetadata =
+            isSelected &&
+            requiredMetadata &&
+            requiredMetadata.some(([key, type]) => {
+              const value = isSelected[key] as
+                | string
+                | number
+                | string[]
+                | undefined;
+              if (value === undefined) return true;
+              if (type === 'number' || type === 'catastrophe')
+                return isNaN(Number(value));
+              if (type === 'card_per_person') {
+                return (
+                  (value as string[]).length !== playerCount &&
+                  (value as string[]).some((v) => v === '')
+                );
+              }
+              return value === '';
+            });
+
           return (
             <div
               key={card.name}
-              className={`card catastrophe-card${isSelected ? ' selected' : ''}`}
-              onClick={() => onToggle(card.name)}
+              className={`card catastrophe-card${isSelected ? ' selected' : ''}${missingMetadata ? ' metadata-missing' : ''}`}
+              onClick={() => clickCard(card.name)}
               onMouseEnter={() => onHover(card.name)}
               onMouseLeave={() => onHover(null)}
             >
@@ -229,9 +264,11 @@ function CatastropheInline({
                   (e.target as HTMLImageElement).style.display = 'none';
                 }}
               />
-              {selectedCatastrophes.indexOf(card.name) !== -1 && (
+              {selectedCatastrophes.find((c) => c.name === card.name) && (
                 <div className="card-count">
-                  {selectedCatastrophes.indexOf(card.name) + 1}
+                  {selectedCatastrophes.indexOf(
+                    selectedCatastrophes.find((c) => c.name === card.name)!
+                  ) + 1}
                 </div>
               )}
               <span className="pack-card-name">{card.name}</span>

--- a/web/src/hooks/useScorer.ts
+++ b/web/src/hooks/useScorer.ts
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { Scorer, GameScore } from '@scorer/scorer';
-import type { PlayerState } from '../types';
+import type { CardEntry, PlayerState } from '../types';
 import type { PlayerInput } from '@scorer/types';
 
 export interface CatastropheState {
@@ -10,7 +10,7 @@ export interface CatastropheState {
 
 export function useScorer(
   players: PlayerState[],
-  selectedCatastrophes: string[],
+  selectedCatastrophes: CardEntry[],
   catastropheMetadata: Record<
     string,
     Record<string, string | number | string[]>
@@ -27,9 +27,9 @@ export function useScorer(
 
       if (selectedCatastrophes.length > 0) {
         const catastropheInputs: PlayerInput[] = selectedCatastrophes.map(
-          (name) => ({
-            name,
-            ...catastropheMetadata[name]
+          (catastrophe) => ({
+            ...catastrophe,
+            ...catastropheMetadata[catastrophe.name]
           })
         );
         scorer.addCatastrophes(catastropheInputs);

--- a/web/src/types.ts
+++ b/web/src/types.ts
@@ -3,10 +3,10 @@ import type { Card, CardType, PackType } from '@scorer/types';
 export interface PlayerState {
   id: number;
   name: string;
-  cards: PlayerCardEntry[];
+  cards: CardEntry[];
 }
 
-export interface PlayerCardEntry {
+export interface CardEntry {
   name: string;
   [key: string]: string | number | string[];
 }
@@ -30,6 +30,10 @@ export interface CardGroup {
 export interface ModalState {
   playerId: number;
   cardIndex: number;
+  cardName: string;
+}
+
+export interface CatastropheModalState {
   cardName: string;
 }
 

--- a/web/src/utils/cardMetadata.ts
+++ b/web/src/utils/cardMetadata.ts
@@ -1,6 +1,6 @@
 import { allCards } from '@scorer/cardContainer';
 import type { MetaDataType, MetaDataScope } from '@scorer/types';
-import type { PlayerCardEntry } from '../types';
+import type { CardEntry } from '../types';
 
 export interface MetadataField {
   key: string;
@@ -29,9 +29,17 @@ export function getInternalMetadataFields(cardName: string): MetadataField[] {
   return getCardMetadataFields(cardName).filter((f) => f.scope === 'internal');
 }
 
+export function getCatastropheMetadataFields(metadata: Record<string, string | number | string[]> | undefined): MetadataField[] {
+  if (metadata === undefined) return []
+  return Object.keys(metadata).map((key) => ({
+    key,
+    type: metadata[key] as unknown as MetaDataType,
+    scope: 'internal'
+  } as MetadataField));
+}
 /** Checks if user-required metadata is complete (ignores internal fields) */
 export function isMetadataComplete(
-  card: PlayerCardEntry,
+  card: CardEntry,
   fields: MetadataField[]
 ): boolean {
   const editableFields = fields.filter((f) => f.scope !== 'internal');


### PR DESCRIPTION
This didn't work, but now it does, as well as display for invalid/missing data.